### PR TITLE
Enables flash messages to propagate across redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,5 +32,9 @@ module.exports = function (opts) {
     });
 
     yield *next;
+
+    if (this.status == 302 && this.session && !(this.session[key])) {
+      this.session[key] = data;
+    }
   };
 };


### PR DESCRIPTION
We're using koa-flash in an application that redirects on a lot of paths, and our flash messages get swallowed up when we do this, resulting in the user not seeing the intended message when they get to the final redirect location. 

This change lets you propagate the flash messages automatically across a redirect unless you explicitly set it to something else while handling the request before redirecting. 
